### PR TITLE
Bring Back Some Cleanup

### DIFF
--- a/src/main/java/com/lootbeams/Configuration.java
+++ b/src/main/java/com/lootbeams/Configuration.java
@@ -152,46 +152,46 @@ public class Configuration {
 
 	public static Color getColorFromItemOverrides(Item i) {
 		List<String> overrides = COLOR_OVERRIDES.get();
-		if (overrides.size() > 0) {
-			for (String unparsed : overrides.stream().filter((s) -> (!s.isEmpty())).collect(Collectors.toList())) {
-				String[] configValue = unparsed.split("=");
-				if (configValue.length == 2) {
-					String nameIn = configValue[0];
-					ResourceLocation registry = ResourceLocation.tryParse(nameIn.replace("#", ""));
-					Color colorIn = null;
-					try {
-						colorIn = Color.decode(configValue[1]);
-					} catch (Exception e) {
-						LootBeams.LOGGER.error(String.format("Color overrides error! \"%s\" is not a valid hex color for \"%s\"", configValue[1], nameIn));
-						return null;
-					}
+		if (overrides.isEmpty()) {
+			return null;
+		}
 
-					//Modid
-					if (!nameIn.contains(":")) {
-						if (ForgeRegistries.ITEMS.getKey(i).getNamespace().equals(nameIn)) {
-							return colorIn;
-						}
+		for (String unparsed : overrides.stream().filter(s -> !s.isEmpty()).toList()) {
+			String[] configValue = unparsed.split("=");
+			if (configValue.length != 2) {
+				continue;
+			}
 
-					}
+			String nameIn = configValue[0];
+			ResourceLocation registry = ResourceLocation.tryParse(nameIn.replace("#", ""));
+			Color colorIn;
+			try {
+				colorIn = Color.decode(configValue[1]);
+			} catch (Exception e) {
+				LootBeams.LOGGER.error(String.format("Color overrides error! \"%s\" is not a valid hex color for \"%s\"", configValue[1], nameIn));
+				return null;
+			}
 
-					if (registry != null) {
-						//Tag
-						if (nameIn.startsWith("#")) {
-							if (ForgeRegistries.ITEMS.tags().getTag(TagKey.create(Registry.ITEM_REGISTRY, registry)).contains(i)) {
-								return colorIn;
-							}
-						}
+			// Mod id
+			if (!nameIn.contains(":") && ForgeRegistries.ITEMS.getKey(i).getNamespace().equals(nameIn)) {
+				return colorIn;
+			}
 
-						//Item
-						Item registryItem = ForgeRegistries.ITEMS.getValue(registry);
-						if (registryItem != null && registryItem.asItem() == i) {
-							return colorIn;
-						}
-
-					}
+			if (registry != null) {
+				// Tag
+				if (nameIn.startsWith("#") && ForgeRegistries.ITEMS.tags().getTag(TagKey.create(Registry.ITEM_REGISTRY, registry)).contains(i)) {
+					return colorIn;
 				}
+
+				// Item
+				Item registryItem = ForgeRegistries.ITEMS.getValue(registry);
+				if (registryItem != null && registryItem.asItem() == i) {
+					return colorIn;
+				}
+
 			}
 		}
+
 		return null;
 	}
 }

--- a/src/main/java/com/lootbeams/LootBeamRenderer.java
+++ b/src/main/java/com/lootbeams/LootBeamRenderer.java
@@ -20,7 +20,6 @@ import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.Mth;
 import net.minecraft.util.StringDecomposer;
 import net.minecraft.util.StringUtil;
 import net.minecraft.world.entity.Entity;
@@ -28,7 +27,6 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.TooltipFlag;
-import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.fml.ModList;
 
@@ -54,21 +52,22 @@ public class LootBeamRenderer extends RenderType {
     private static final RenderType GLOW = Configuration.GLOWING_BEAM.get() ? RenderType.entityTranslucentEmissive(GLOW_TEXTURE) : RenderType.entityCutout(GLOW_TEXTURE);
 
     private static final Random RANDOM = new Random();
-    private static final XoroshiroRandomSource RANDOM_SOURCE = new XoroshiroRandomSource(42L);
 
     public LootBeamRenderer(String name, VertexFormat format, VertexFormat.Mode mode, int size, boolean crumble, boolean sorting, Runnable enable, Runnable disable) {
         super(name, format, mode, size, crumble, sorting, enable, disable);
     }
 
-    public static void renderLootBeam(PoseStack stack, MultiBufferSource buffer, float pticks, long worldtime, ItemEntity item) {
+    public static void renderLootBeam(PoseStack stack, MultiBufferSource buffer, float pTicks, long worldTime, ItemEntity item) {
         RenderSystem.enableDepthTest();
         float beamAlpha = Configuration.BEAM_ALPHA.get().floatValue();
         float entityTime = item.tickCount;
-        //Fade out when close
+
+        // Fade out when close
         if (Minecraft.getInstance().player.distanceToSqr(item) < 2f) {
             beamAlpha *= Minecraft.getInstance().player.distanceToSqr(item);
         }
-        //Dont render beam if its too transparent
+
+        // Don't render beam if its too transparent
         if (beamAlpha <= 0.15f) {
             return;
         }
@@ -77,33 +76,31 @@ public class LootBeamRenderer extends RenderType {
         float glowRadius = beamRadius + (beamRadius * 0.2f);
         float beamHeight = Configuration.BEAM_HEIGHT.get().floatValue();
         float yOffset = Configuration.BEAM_Y_OFFSET.get().floatValue();
-        if(Configuration.COMMON_SHORTER_BEAM.get()){
-            if(!compatRarityCheck(item, false)){
-                beamHeight *= 0.65f;
-                yOffset -= yOffset;
-            }
+        if (Configuration.COMMON_SHORTER_BEAM.get() && !compatRarityCheck(item, false)) {
+            beamHeight *= 0.65f;
+            yOffset -= yOffset;
         }
 
 
         Color color = getItemColor(item);
-        float R = color.getRed() / 255f;
-        float G = color.getGreen() / 255f;
-        float B = color.getBlue() / 255f;
+        float r = color.getRed() / 255f;
+        float g = color.getGreen() / 255f;
+        float b = color.getBlue() / 255f;
 
-        //I will rewrite the beam rendering code soon! I promise!
+        // I will rewrite the beam rendering code soon! I promise!
 
         stack.pushPose();
 
-        //Render main beam
+        // Render main beam
         stack.pushPose();
-        float rotation = (float) Math.floorMod(worldtime, 40L) + pticks;
+        float rotation = (float) Math.floorMod(worldTime, 40L) + pTicks;
         stack.mulPose(Vector3f.YP.rotationDegrees(rotation * 2.25F - 45.0F));
         stack.translate(0, yOffset, 0);
         stack.translate(0, 1, 0);
         stack.mulPose(Vector3f.XP.rotationDegrees(180));
-        renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), R, G, B, beamAlpha, beamHeight, 0.0F, beamRadius, beamRadius, 0.0F, -beamRadius, 0.0F, 0.0F, -beamRadius, false);
+        renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), r, g, b, beamAlpha, beamHeight, 0.0F, beamRadius, beamRadius, 0.0F, -beamRadius, 0.0F, 0.0F, -beamRadius, false);
         stack.mulPose(Vector3f.XP.rotationDegrees(-180));
-        renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), R, G, B, beamAlpha, beamHeight, 0.0F, beamRadius, beamRadius, 0.0F, -beamRadius, 0.0F, 0.0F, -beamRadius, Configuration.SOLID_BEAM.get());
+        renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), r, g, b, beamAlpha, beamHeight, 0.0F, beamRadius, beamRadius, 0.0F, -beamRadius, 0.0F, 0.0F, -beamRadius, Configuration.SOLID_BEAM.get());
         stack.popPose();
 
         //Render glow around main beam
@@ -111,9 +108,9 @@ public class LootBeamRenderer extends RenderType {
         stack.translate(0, yOffset, 0);
         stack.translate(0, 1, 0);
         stack.mulPose(Vector3f.XP.rotationDegrees(180));
-        renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), R, G, B, beamAlpha * 0.4f, beamHeight, -glowRadius, -glowRadius, glowRadius, -glowRadius, -beamRadius, glowRadius, glowRadius, glowRadius, false);
+        renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), r, g, b, beamAlpha * 0.4f, beamHeight, -glowRadius, -glowRadius, glowRadius, -glowRadius, -beamRadius, glowRadius, glowRadius, glowRadius, false);
         stack.mulPose(Vector3f.XP.rotationDegrees(-180));
-        renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), R, G, B, beamAlpha * 0.4f, beamHeight, -glowRadius, -glowRadius, glowRadius, -glowRadius, -beamRadius, glowRadius, glowRadius, glowRadius, Configuration.SOLID_BEAM.get());
+        renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), r, g, b, beamAlpha * 0.4f, beamHeight, -glowRadius, -glowRadius, glowRadius, -glowRadius, -beamRadius, glowRadius, glowRadius, glowRadius, Configuration.SOLID_BEAM.get());
         stack.popPose();
 
         if (Configuration.WHITE_CENTER.get()) {
@@ -121,9 +118,9 @@ public class LootBeamRenderer extends RenderType {
             stack.translate(0, yOffset, 0);
             stack.translate(0, 1, 0);
             stack.mulPose(Vector3f.XP.rotationDegrees(180));
-            renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), R, G, B, beamAlpha, beamHeight, 0.0F, beamRadius * 0.4f, beamRadius * 0.4f, 0.0F, -beamRadius * 0.4f, 0.0F, 0.0F, -beamRadius * 0.4f, false);
+            renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), r, g, b, beamAlpha, beamHeight, 0.0F, beamRadius * 0.4f, beamRadius * 0.4f, 0.0F, -beamRadius * 0.4f, 0.0F, 0.0F, -beamRadius * 0.4f, false);
             stack.mulPose(Vector3f.XP.rotationDegrees(-180));
-            renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), R, G, B, beamAlpha, beamHeight, 0.0F, beamRadius * 0.4f, beamRadius * 0.4f, 0.0F, -beamRadius * 0.4f, 0.0F, 0.0F, -beamRadius * 0.4f, Configuration.SOLID_BEAM.get());
+            renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), r, g, b, beamAlpha, beamHeight, 0.0F, beamRadius * 0.4f, beamRadius * 0.4f, 0.0F, -beamRadius * 0.4f, 0.0F, 0.0F, -beamRadius * 0.4f, Configuration.SOLID_BEAM.get());
             stack.popPose();
         }
 
@@ -132,11 +129,11 @@ public class LootBeamRenderer extends RenderType {
             stack.translate(0, 0.001f, 0);
             float radius = Configuration.GLOW_EFFECT_RADIUS.get().floatValue();
             if (Configuration.ANIMATE_GLOW.get()) {
-                beamAlpha *= (Math.abs(Math.cos((entityTime + pticks) / 10f)) * 0.5f + 0.5f) * 1.3f;
-                radius *= ((Math.abs(Math.cos((entityTime + pticks) / 10f) * 0.45f)) * 0.75f + 0.75f);
+                beamAlpha *= (Math.abs(Math.cos((entityTime + pTicks) / 10f)) * 0.5f + 0.5f) * 1.3f;
+                radius *= ((Math.abs(Math.cos((entityTime + pTicks) / 10f) * 0.45f)) * 0.75f + 0.75f);
             }
 
-            renderGlow(stack, buffer.getBuffer(GLOW), R, G, B, beamAlpha * 0.4f, radius);
+            renderGlow(stack, buffer.getBuffer(GLOW), r, g, b, beamAlpha * 0.4f, radius);
             stack.popPose();
         }
         stack.popPose();
@@ -145,39 +142,22 @@ public class LootBeamRenderer extends RenderType {
             renderNameTag(stack, buffer, item, color);
         }
 
-        if (Configuration.PARTICLES.get()) {
-            if (!Configuration.PARTICLE_RARE_ONLY.get()) {
-                renderParticles(pticks, item, (int) entityTime, R, G, B);
-            } else {
-                boolean shouldRender = false;
-                shouldRender = compatRarityCheck(item, shouldRender);
-                if (shouldRender) {
-                    renderParticles(pticks, item, (int) entityTime, R, G, B);
-                }
-            }
-
+        if (Configuration.PARTICLES.get() && (!Configuration.PARTICLE_RARE_ONLY.get() || compatRarityCheck(item, false))) {
+            renderParticles(pTicks, item, (int) entityTime, r, g, b);
         }
+
         RenderSystem.disableDepthTest();
     }
 
-    static boolean compatRarityCheck(ItemEntity item, boolean shouldRender) {
-        if(ModList.get().isLoaded("apotheosis")){
-            if(ApotheosisCompat.isApotheosisItem(item.getItem())){
-                if(!ApotheosisCompat.getRarityName(item.getItem()).equals("common") || item.getItem().getRarity() != Rarity.COMMON){
-                    shouldRender = true;
-                }
-            }
-        } else {
-            if (item.getItem().getRarity() != Rarity.COMMON) {
-                shouldRender = true;
-            }
-        }
-        return shouldRender;
+    static boolean compatRarityCheck(ItemEntity item, boolean isRare) {
+        return isRare
+                || item.getItem().getRarity() != Rarity.COMMON
+                || (ModList.get().isLoaded("apotheosis") && ApotheosisCompat.isApotheosisItem(item.getItem()) && !ApotheosisCompat.getRarityName(item.getItem()).equals("common"));
     }
 
-    private static void renderParticles(float pticks, ItemEntity item, int entityTime, float r, float g, float b) {
+    private static void renderParticles(float pTicks, ItemEntity item, int entityTime, float r, float g, float b) {
         float particleCount = Math.abs(20- Configuration.PARTICLE_COUNT.get().floatValue());
-        if (entityTime % particleCount == 0 && pticks < 0.3f && !Minecraft.getInstance().isPaused()) {
+        if (entityTime % particleCount == 0 && pTicks < 0.3f && !Minecraft.getInstance().isPaused()) {
             addParticle(ModClientEvents.GLOW_TEXTURE, r, g, b, 1.0f, Configuration.PARTICLE_LIFETIME.get(), RANDOM.nextFloat((float) (0.25f * Configuration.PARTICLE_SIZE.get()), (float) (1.1f * Configuration.PARTICLE_SIZE.get())), new Vec3(
                             RANDOM.nextDouble(item.getX() - Configuration.PARTICLE_RADIUS.get(), item.getX() + Configuration.PARTICLE_RADIUS.get()),
                             RANDOM.nextDouble(item.getY() - (Configuration.PARTICLE_RADIUS.get()/3f), item.getY() + (Configuration.PARTICLE_RADIUS.get()/3f)),
@@ -188,111 +168,108 @@ public class LootBeamRenderer extends RenderType {
         }
     }
 
-    private static double pulse(float entityTime, float max) {
-        double val = Math.cos(entityTime / 10f) * 0.5f + 0.5f;
-        return Mth.lerp(val, 0.25f, max);
-    }
-
     private static void addParticle(ResourceLocation spriteLocation, float red, float green, float blue, float alpha, int lifetime, float size, Vec3 pos, Vec3 motion) {
-        Minecraft mc = Minecraft.getInstance();
-        //make the particle brighter
+        // Make the particle brighter
         alpha *= 1.5f;
+        Minecraft mc = Minecraft.getInstance();
         VFXParticle provider = new VFXParticle(mc.level, mc.particleEngine.textureAtlas.getSprite(spriteLocation), red, green, blue, alpha, lifetime, size, pos, motion, 0, false, true);
         mc.particleEngine.add(provider);
     }
 
     private static void renderGlow(PoseStack stack, VertexConsumer builder, float red, float green, float blue, float alpha, float radius) {
-        PoseStack.Pose matrixentry = stack.last();
-        Matrix4f matrixpose = matrixentry.pose();
-        Matrix3f matrixnormal = matrixentry.normal();
-        // draw a quad on the xz plane facing up with a radius of 0.5
-        builder.vertex(matrixpose, -radius, (float) 0, -radius).color(red, green, blue, alpha).uv(0, 0).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(matrixnormal, 0.0F, 1.0F, 0.0F).endVertex();
-        builder.vertex(matrixpose, -radius, (float) 0, radius).color(red, green, blue, alpha).uv(0, 1).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(matrixnormal, 0.0F, 1.0F, 0.0F).endVertex();
-        builder.vertex(matrixpose, radius, (float) 0, radius).color(red, green, blue, alpha).uv(1, 1).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(matrixnormal, 0.0F, 1.0F, 0.0F).endVertex();
-        builder.vertex(matrixpose, radius, (float) 0, -radius).color(red, green, blue, alpha).uv(1, 0).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(matrixnormal, 0.0F, 1.0F, 0.0F).endVertex();
+        PoseStack.Pose matrixEntry = stack.last();
+        Matrix4f matrixPose = matrixEntry.pose();
+        Matrix3f matrixNormal = matrixEntry.normal();
+
+        // Draw a quad on the xz plane facing up with a radius of 0.5
+        builder.vertex(matrixPose, -radius, (float) 0, -radius).color(red, green, blue, alpha).uv(0, 0).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(matrixNormal, 0.0F, 1.0F, 0.0F).endVertex();
+        builder.vertex(matrixPose, -radius, (float) 0, radius).color(red, green, blue, alpha).uv(0, 1).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(matrixNormal, 0.0F, 1.0F, 0.0F).endVertex();
+        builder.vertex(matrixPose, radius, (float) 0, radius).color(red, green, blue, alpha).uv(1, 1).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(matrixNormal, 0.0F, 1.0F, 0.0F).endVertex();
+        builder.vertex(matrixPose, radius, (float) 0, -radius).color(red, green, blue, alpha).uv(1, 0).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(matrixNormal, 0.0F, 1.0F, 0.0F).endVertex();
     }
 
-    private static void renderNameTag(PoseStack stack, MultiBufferSource buffer, ItemEntity item, Color color) {
-        //If player is crouching or looking at the item
-        if (Minecraft.getInstance().player.isCrouching() || (Configuration.RENDER_NAMETAGS_ONLOOK.get() && isLookingAt(Minecraft.getInstance().player, item, Configuration.NAMETAG_LOOK_SENSITIVITY.get()))) {
-            float foregroundAlpha = Configuration.NAMETAG_TEXT_ALPHA.get().floatValue();
-            float backgroundAlpha = Configuration.NAMETAG_BACKGROUND_ALPHA.get().floatValue();
-            double yOffset = Configuration.NAMETAG_Y_OFFSET.get();
-            int foregroundColor = new Color(color.getRed(), color.getGreen(), color.getBlue(), (int) (255 * foregroundAlpha)).getRGB();
-            int backgroundColor = new Color(color.getRed(), color.getGreen(), color.getBlue(), (int) (255 * backgroundAlpha)).getRGB();
+    private static void renderNameTag(PoseStack stack, MultiBufferSource buffer, ItemEntity ie, Color color) {
+        // If player is crouching or looking at the item
+        Minecraft instance = Minecraft.getInstance();
+        if (!instance.player.isCrouching() && !(Configuration.RENDER_NAMETAGS_ONLOOK.get() && isLookingAt(instance.player, ie, Configuration.NAMETAG_LOOK_SENSITIVITY.get()))) {
+            return;
+        }
 
-            stack.pushPose();
+        double yOffset = Configuration.NAMETAG_Y_OFFSET.get();
+        float nametagScale = Configuration.NAMETAG_SCALE.get().floatValue();
+        float foregroundAlpha = Configuration.NAMETAG_TEXT_ALPHA.get().floatValue();
+        float backgroundAlpha = Configuration.NAMETAG_BACKGROUND_ALPHA.get().floatValue();
+        int foregroundColor = new Color(color.getRed(), color.getGreen(), color.getBlue(), (int) (255 * foregroundAlpha)).getRGB();
+        int backgroundColor = new Color(color.getRed(), color.getGreen(), color.getBlue(), (int) (255 * backgroundAlpha)).getRGB();
 
-            //Render nametags at heights based on player distance
-            stack.translate(0.0D, Math.min(1D, Minecraft.getInstance().player.distanceToSqr(item) * 0.025D) + yOffset, 0.0D);
-            stack.mulPose(Minecraft.getInstance().getEntityRenderDispatcher().cameraOrientation());
+        stack.pushPose();
 
-            float nametagScale = Configuration.NAMETAG_SCALE.get().floatValue();
-            stack.scale(-0.02F * nametagScale, -0.02F * nametagScale, 0.02F * nametagScale);
+        // Render nametags at heights based on player distance
+        stack.translate(0.0D, Math.min(1D, instance.player.distanceToSqr(ie) * 0.025D) + yOffset, 0.0D);
+        stack.mulPose(instance.getEntityRenderDispatcher().cameraOrientation());
+        stack.scale(-0.02F * nametagScale, -0.02F * nametagScale, 0.02F * nametagScale);
 
-            //Render stack counts on nametag
-            Font fontrenderer = Minecraft.getInstance().font;
-            String itemName = StringUtil.stripColor(item.getItem().getHoverName().getString());
-            if (Configuration.RENDER_STACKCOUNT.get()) {
-                int count = item.getItem().getCount();
-                if (count > 1) {
-                    itemName = itemName + " x" + count;
-                }
+        // Render stack counts on nametag
+        Font fontRenderer = instance.font;
+        String itemName = StringUtil.stripColor(ie.getItem().getHoverName().getString());
+        if (Configuration.RENDER_STACKCOUNT.get()) {
+            int count = ie.getItem().getCount();
+            if (count > 1) {
+                itemName = itemName + " x" + count;
+            }
+        }
+
+        // Move closer to the player so that we don't render in beam, and render the tag
+        stack.translate(0, 0, -10);
+        renderText(fontRenderer, stack, buffer, itemName, foregroundColor, backgroundColor, backgroundAlpha);
+
+        // Render small tags
+        stack.translate(0.0D, 10, 0.0D);
+        stack.scale(0.75f, 0.75f, 0.75f);
+        boolean textDrawn = false;
+        List<Component> tooltip;
+        if (!TOOLTIP_CACHE.containsKey(ie)) {
+            tooltip = ie.getItem().getTooltipLines(null, TooltipFlag.Default.NORMAL);
+            TOOLTIP_CACHE.put(ie, tooltip);
+        } else {
+            tooltip = TOOLTIP_CACHE.get(ie);
+        }
+
+        if (tooltip.size() >= 2) {
+            Component tooltipRarity = tooltip.get(1);
+
+            // Render dmcloot rarity small tags
+            if (Configuration.DMCLOOT_COMPAT_RARITY.get() && ModList.get().isLoaded("dmcloot") && ie.getItem().hasTag() && ie.getItem().getTag().contains("dmcloot.rarity")) {
+                Color rarityColor = Configuration.WHITE_RARITIES.get() ? Color.WHITE : getRawColor(tooltipRarity);
+                Component translatedRarity = Component.translatable("rarity.dmcloot." + ie.getItem().getTag().getString("dmcloot.rarity"));
+                renderText(fontRenderer, stack, buffer, translatedRarity.getString(), rarityColor.getRGB(), backgroundColor, backgroundAlpha);
+                textDrawn = true;
             }
 
-            //Move closer to the player so we dont render in beam, and render the tag
-            stack.translate(0, 0, -10);
-            renderText(fontrenderer, stack, buffer, itemName, foregroundColor, backgroundColor, backgroundAlpha);
-
-            //Render small tags
-            stack.translate(0.0D, 10, 0.0D);
-            stack.scale(0.75f, 0.75f, 0.75f);
-            boolean textDrawn = false;
-            List<Component> tooltip;
-            if (!TOOLTIP_CACHE.containsKey(item)) {
-                tooltip = item.getItem().getTooltipLines(null, TooltipFlag.Default.NORMAL);
-                TOOLTIP_CACHE.put(item, tooltip);
-            } else {
-                tooltip = TOOLTIP_CACHE.get(item);
-            }
-            if (tooltip.size() >= 2) {
-                Component tooltipRarity = tooltip.get(1);
-
-                //Render dmcloot rarity small tags
-                if (Configuration.DMCLOOT_COMPAT_RARITY.get() && ModList.get().isLoaded("dmcloot")) {
-                    if (item.getItem().hasTag() && item.getItem().getTag().contains("dmcloot.rarity")) {
-                        Color rarityColor = Configuration.WHITE_RARITIES.get() ? Color.WHITE : getRawColor(tooltipRarity);
-                        Component translatedRarity = Component.translatable("rarity.dmcloot." + item.getItem().getTag().getString("dmcloot.rarity"));
-                        renderText(fontrenderer, stack, buffer, translatedRarity.getString(), rarityColor.getRGB(), backgroundColor, backgroundAlpha);
-                        textDrawn = true;
-                    }
-                }
-
-                //Render custom rarities
-                if (!textDrawn && Configuration.CUSTOM_RARITIES.get().contains(tooltipRarity.getString())) {
-                    Color rarityColor = Configuration.WHITE_RARITIES.get() ? Color.WHITE : getRawColor(tooltipRarity);
-                    foregroundColor = new Color(rarityColor.getRed(), rarityColor.getGreen(), rarityColor.getBlue(), (int) (255 * foregroundAlpha)).getRGB();
-                    backgroundColor = new Color(rarityColor.getRed(), rarityColor.getGreen(), rarityColor.getBlue(), (int) (255 * backgroundAlpha)).getRGB();
-                    renderText(fontrenderer, stack, buffer, tooltipRarity.getString(), foregroundColor, backgroundColor, backgroundAlpha);
-                }
-
-            }
-            if (!textDrawn && Configuration.VANILLA_RARITIES.get()) {
-                Color rarityColor = getRawColor(tooltip.get(0));
+            // Render custom rarities
+            if (!textDrawn && Configuration.CUSTOM_RARITIES.get().contains(tooltipRarity.getString())) {
+                Color rarityColor = Configuration.WHITE_RARITIES.get() ? Color.WHITE : getRawColor(tooltipRarity);
                 foregroundColor = new Color(rarityColor.getRed(), rarityColor.getGreen(), rarityColor.getBlue(), (int) (255 * foregroundAlpha)).getRGB();
                 backgroundColor = new Color(rarityColor.getRed(), rarityColor.getGreen(), rarityColor.getBlue(), (int) (255 * backgroundAlpha)).getRGB();
-                String rarity = item.getItem().getRarity().name().toLowerCase();
-                if (ModList.get().isLoaded("apotheosis")) {
-                    if (ApotheosisCompat.isApotheosisItem(item.getItem())) {
-                        rarity = ApotheosisCompat.getRarityName(item.getItem());
-                    }
-                }
-                renderText(fontrenderer, stack, buffer, capitalize(rarity), foregroundColor, backgroundColor, backgroundAlpha);
+                renderText(fontRenderer, stack, buffer, tooltipRarity.getString(), foregroundColor, backgroundColor, backgroundAlpha);
+                textDrawn = true;
             }
-
-            stack.popPose();
         }
+
+        if (!textDrawn && Configuration.VANILLA_RARITIES.get()) {
+            Color rarityColor = getRawColor(tooltip.get(0));
+            foregroundColor = new Color(rarityColor.getRed(), rarityColor.getGreen(), rarityColor.getBlue(), (int) (255 * foregroundAlpha)).getRGB();
+            backgroundColor = new Color(rarityColor.getRed(), rarityColor.getGreen(), rarityColor.getBlue(), (int) (255 * backgroundAlpha)).getRGB();
+            String rarity = ie.getItem().getRarity().name().toLowerCase();
+            if (ModList.get().isLoaded("apotheosis") && ApotheosisCompat.isApotheosisItem(ie.getItem())) {
+                rarity = ApotheosisCompat.getRarityName(ie.getItem());
+            }
+            renderText(fontRenderer, stack, buffer, capitalize(rarity), foregroundColor, backgroundColor, backgroundAlpha);
+        }
+
+        stack.popPose();
     }
+
 
     private static String capitalize(String str) {
         if (str == null || str.isEmpty()) {
@@ -303,23 +280,24 @@ public class LootBeamRenderer extends RenderType {
     }
 
     private static void renderText(Font fontRenderer, PoseStack stack, MultiBufferSource buffer, String text, int foregroundColor, int backgroundColor, float backgroundAlpha) {
-        if (Configuration.BORDERS.get()) {
-            float w = -fontRenderer.width(text) / 2f;
-            int bg = new Color(0, 0, 0, (int) (255 * backgroundAlpha)).getRGB();
-
-            //Draws background (border) text
-            fontRenderer.draw(stack, text, w + 1f, 0, bg);
-            fontRenderer.draw(stack, text, w - 1f, 0, bg);
-            fontRenderer.draw(stack, text, w, 1f, bg);
-            fontRenderer.draw(stack, text, w, -1f, bg);
-
-            //Draws foreground text in front of border
-            stack.translate(0.0D, 0.0D, -0.01D);
-            fontRenderer.draw(stack, text, w, 0, foregroundColor);
-            stack.translate(0.0D, 0.0D, 0.01D);
-        } else {
-            fontRenderer.drawInBatch(text, (float) (-fontRenderer.width(text) / 2), 0f, foregroundColor, false, stack.last().pose(), buffer, false, backgroundColor, 15728864);
+        if (!Configuration.BORDERS.get()) {
+            fontRenderer.drawInBatch(text, (float) (-fontRenderer.width(text) / 2D), 0f, foregroundColor, false, stack.last().pose(), buffer, false, backgroundColor, 15728864);
+            return;
         }
+
+        float w = -fontRenderer.width(text) / 2f;
+        int bg = new Color(0, 0, 0, (int) (255 * backgroundAlpha)).getRGB();
+
+        // Draws background (border) text
+        fontRenderer.draw(stack, text, w + 1f, 0, bg);
+        fontRenderer.draw(stack, text, w - 1f, 0, bg);
+        fontRenderer.draw(stack, text, w, 1f, bg);
+        fontRenderer.draw(stack, text, w, -1f, bg);
+
+        // Draws foreground text in front of border
+        stack.translate(0.0D, 0.0D, -0.01D);
+        fontRenderer.draw(stack, text, w, 0, foregroundColor);
+        stack.translate(0.0D, 0.0D, 0.01D);
     }
 
     /**
@@ -331,19 +309,18 @@ public class LootBeamRenderer extends RenderType {
         }
 
         try {
-
-            //From Config Overrides
+            // From Config Overrides
             Color override = Configuration.getColorFromItemOverrides(item.getItem().getItem());
             if (override != null) {
                 return override;
             }
 
-            //From NBT
+            // From NBT
             if (item.getItem().hasTag() && item.getItem().getTag().contains("lootbeams.color")) {
                 return Color.decode(item.getItem().getTag().getString("lootbeams.color"));
             }
 
-            //From Name
+            // From Name
             if (Configuration.RENDER_NAME_COLOR.get()) {
                 Color nameColor = getRawColor(item.getItem().getHoverName());
                 if (!nameColor.equals(Color.WHITE)) {
@@ -351,7 +328,7 @@ public class LootBeamRenderer extends RenderType {
                 }
             }
 
-            //From Rarity
+            // From Rarity
             if (Configuration.RENDER_RARITY_COLOR.get() && item.getItem().getRarity().getStyleModifier().apply(Style.EMPTY).getColor() != null) {
                 return new Color(item.getItem().getRarity().getStyleModifier().apply(Style.EMPTY).getColor().getValue());
             } else {
@@ -373,6 +350,7 @@ public class LootBeamRenderer extends RenderType {
      */
     private static Color getRawColor(Component text) {
         List<Style> list = Lists.newArrayList();
+
         text.visit((acceptor, styleIn) -> {
             StringDecomposer.iterateFormatted(styleIn, acceptor, (string, style, consumer) -> {
                 list.add(style);
@@ -380,56 +358,33 @@ public class LootBeamRenderer extends RenderType {
             });
             return Optional.empty();
         }, Style.EMPTY);
+
         if (list.get(0).getColor() != null) {
             return new Color(list.get(0).getColor().getValue());
         }
+
         return Color.WHITE;
     }
 
-    private static void renderPart(PoseStack stack, VertexConsumer builder, float red, float green, float blue, float alpha, float height, float radius_1, float radius_2, float radius_3, float radius_4, float radius_5, float radius_6, float radius_7, float radius_8, boolean gradient) {
-        if (gradient) {
-            renderGradientPart(stack, builder, red, green, blue, alpha, height, radius_1, radius_2, radius_3, radius_4, radius_5, radius_6, radius_7, radius_8);
-        } else {
-            renderPart(stack, builder, red, green, blue, alpha, height, radius_1, radius_2, radius_3, radius_4, radius_5, radius_6, radius_7, radius_8);
-        }
+    private static void renderPart(PoseStack stack, VertexConsumer builder, float red, float green, float blue, float alpha, float height, float radius1, float radius2, float radius3, float radius4, float radius5, float radius6, float radius7, float radius8, boolean gradient) {
+        PoseStack.Pose matrixEntry = stack.last();
+        Matrix4f matrixPose = matrixEntry.pose();
+        Matrix3f matrixNormal = matrixEntry.normal();
+        renderQuad(matrixPose, matrixNormal, builder, red, green, blue, alpha, height, radius1, radius2, radius3, radius4, gradient);
+        renderQuad(matrixPose, matrixNormal, builder, red, green, blue, alpha, height, radius7, radius8, radius5, radius6, gradient);
+        renderQuad(matrixPose, matrixNormal, builder, red, green, blue, alpha, height, radius3, radius4, radius7, radius8, gradient);
+        renderQuad(matrixPose, matrixNormal, builder, red, green, blue, alpha, height, radius5, radius6, radius1, radius2, gradient);
     }
 
-    private static void renderPart(PoseStack stack, VertexConsumer builder, float red, float green, float blue, float alpha, float height, float radius_1, float radius_2, float radius_3, float radius_4, float radius_5, float radius_6, float radius_7, float radius_8) {
-        PoseStack.Pose matrixentry = stack.last();
-        Matrix4f matrixpose = matrixentry.pose();
-        Matrix3f matrixnormal = matrixentry.normal();
-        renderQuad(matrixpose, matrixnormal, builder, red, green, blue, alpha, height, radius_1, radius_2, radius_3, radius_4);
-        renderQuad(matrixpose, matrixnormal, builder, red, green, blue, alpha, height, radius_7, radius_8, radius_5, radius_6);
-        renderQuad(matrixpose, matrixnormal, builder, red, green, blue, alpha, height, radius_3, radius_4, radius_7, radius_8);
-        renderQuad(matrixpose, matrixnormal, builder, red, green, blue, alpha, height, radius_5, radius_6, radius_1, radius_2);
+    private static void renderQuad(Matrix4f pose, Matrix3f normal, VertexConsumer builder, float red, float green, float blue, float alpha, float y, float x1, float z1, float x2, float z2, boolean gradient) {
+        addVertex(pose, normal, builder, red, green, blue, gradient ? 0.0f : alpha, y, x1, z1, 1f, 0f);
+        addVertex(pose, normal, builder, red, green, blue, alpha, 0f, x1, z1, 1f, 1f);
+        addVertex(pose, normal, builder, red, green, blue, alpha, 0f, x2, z2, 0f, 1f);
+        addVertex(pose, normal, builder, red, green, blue, gradient ? 0.0f : alpha, y, x2, z2, 0f, 0f);
     }
 
-    private static void renderGradientPart(PoseStack stack, VertexConsumer builder, float red, float green, float blue, float alpha, float height, float radius_1, float radius_2, float radius_3, float radius_4, float radius_5, float radius_6, float radius_7, float radius_8) {
-        PoseStack.Pose matrixentry = stack.last();
-        Matrix4f matrixpose = matrixentry.pose();
-        Matrix3f matrixnormal = matrixentry.normal();
-        renderUpwardsGradientQuad(matrixpose, matrixnormal, builder, red, green, blue, alpha, height, radius_1, radius_2, radius_3, radius_4);
-        renderUpwardsGradientQuad(matrixpose, matrixnormal, builder, red, green, blue, alpha, height, radius_7, radius_8, radius_5, radius_6);
-        renderUpwardsGradientQuad(matrixpose, matrixnormal, builder, red, green, blue, alpha, height, radius_3, radius_4, radius_7, radius_8);
-        renderUpwardsGradientQuad(matrixpose, matrixnormal, builder, red, green, blue, alpha, height, radius_5, radius_6, radius_1, radius_2);
-    }
-
-    private static void renderQuad(Matrix4f pose, Matrix3f normal, VertexConsumer builder, float red, float green, float blue, float alpha, float y, float z1, float texu1, float z, float texu) {
-        addVertex(pose, normal, builder, red, green, blue, alpha, y, z1, texu1, 1f, 0f);
-        addVertex(pose, normal, builder, red, green, blue, alpha, 0f, z1, texu1, 1f, 1f);
-        addVertex(pose, normal, builder, red, green, blue, alpha, 0f, z, texu, 0f, 1f);
-        addVertex(pose, normal, builder, red, green, blue, alpha, y, z, texu, 0f, 0f);
-    }
-
-    private static void renderUpwardsGradientQuad(Matrix4f pose, Matrix3f normal, VertexConsumer builder, float red, float green, float blue, float alpha, float y, float z1, float texu1, float z, float texu) {
-        addVertex(pose, normal, builder, red, green, blue, 0.0f, y, z1, texu1, 1f, 0f);
-        addVertex(pose, normal, builder, red, green, blue, alpha, 0f, z1, texu1, 1f, 1f);
-        addVertex(pose, normal, builder, red, green, blue, alpha, 0f, z, texu, 0f, 1f);
-        addVertex(pose, normal, builder, red, green, blue, 0.0f, y, z, texu, 0f, 0f);
-    }
-
-    private static void addVertex(Matrix4f pose, Matrix3f normal, VertexConsumer builder, float red, float green, float blue, float alpha, float y, float x, float z, float texu, float texv) {
-        builder.vertex(pose, x, y, z).color(red, green, blue, alpha).uv(texu, texv).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(normal, 0.0F, 1.0F, 0.0F).endVertex();
+    private static void addVertex(Matrix4f pose, Matrix3f normal, VertexConsumer builder, float red, float green, float blue, float alpha, float y, float x, float z, float u, float v) {
+        builder.vertex(pose, x, y, z).color(red, green, blue, alpha).uv(u, v).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(normal, 0.0F, 1.0F, 0.0F).endVertex();
     }
 
     private static RenderType createRenderType() {

--- a/src/main/java/com/lootbeams/LootBeamRenderer.java
+++ b/src/main/java/com/lootbeams/LootBeamRenderer.java
@@ -103,7 +103,7 @@ public class LootBeamRenderer extends RenderType {
         renderPart(stack, buffer.getBuffer(LOOT_BEAM_RENDERTYPE), r, g, b, beamAlpha, beamHeight, 0.0F, beamRadius, beamRadius, 0.0F, -beamRadius, 0.0F, 0.0F, -beamRadius, Configuration.SOLID_BEAM.get());
         stack.popPose();
 
-        //Render glow around main beam
+        // Render glow around main beam
         stack.pushPose();
         stack.translate(0, yOffset, 0);
         stack.translate(0, 1, 0);

--- a/src/main/java/com/lootbeams/VFXParticle.java
+++ b/src/main/java/com/lootbeams/VFXParticle.java
@@ -1,27 +1,22 @@
 package com.lootbeams;
 
-import com.mojang.blaze3d.vertex.VertexConsumer;
-import net.minecraft.client.Camera;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.*;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.core.particles.SimpleParticleType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.api.distmarker.Dist;
-import net.minecraftforge.api.distmarker.OnlyIn;
-import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public class VFXParticle extends TextureSheetParticle {
-    private final boolean fullbright;
+    private final boolean fullBright;
 
     private boolean stoppedByCollision;
 
     public VFXParticle(ClientLevel clientWorld, TextureAtlasSprite sprite, float r, float g, float b, float a, int lifetime, float size,
-                       Vec3 pos, Vec3 motion, float gravity, boolean collision, boolean fullbright) {
+                       Vec3 pos, Vec3 motion, float gravity, boolean collision, boolean fullBright) {
         super(clientWorld, pos.x, pos.y, pos.z);
         this.setSprite(sprite);
         this.rCol = r;
@@ -35,12 +30,12 @@ public class VFXParticle extends TextureSheetParticle {
         this.zd = motion.z;
         this.gravity = gravity;
         this.hasPhysics = collision;
-        this.fullbright = fullbright;
+        this.fullBright = fullBright;
     }
 
     @Override
     protected int getLightColor(float pPartialTick) {
-        if (this.fullbright) {
+        if (this.fullBright) {
             return LightTexture.pack(15, 15);
         } else {
             return super.getLightColor(pPartialTick);
@@ -68,42 +63,42 @@ public class VFXParticle extends TextureSheetParticle {
 
     @Override
     public void move(double x, double y, double z) {
-        if (!stoppedByCollision) {
-            double dX = x;
-            double dY = y;
-            double dZ = z;
-            if (this.hasPhysics && (x != 0.0D || y != 0.0D || z != 0.0D)) {
-                Vec3 vector3d = Entity.collideBoundingBox(null, new Vec3(x, y, z), this.getBoundingBox(), this.level,
-                        List.of()
-                );
-                x = vector3d.x;
-                y = vector3d.y;
-                z = vector3d.z;
-            }
+        if (stoppedByCollision) {
+            return;
+        }
 
-            if (x != 0.0D || y != 0.0D || z != 0.0D) {
-                this.setBoundingBox(this.getBoundingBox().move(x, y, z));
-                this.setLocationFromBoundingbox();
-            } else {
-                this.stoppedByCollision = true;
-            }
+        double dX = x;
+        double dY = y;
+        double dZ = z;
+        if (this.hasPhysics && (x != 0.0D || y != 0.0D || z != 0.0D)) {
+            Vec3 vector3d = Entity.collideBoundingBox(null, new Vec3(x, y, z), this.getBoundingBox(), this.level, List.of());
+            x = vector3d.x;
+            y = vector3d.y;
+            z = vector3d.z;
+        }
 
-            if (dX != x) {
-                this.xd = 0.0D;
-            }
+        if (x != 0.0D || y != 0.0D || z != 0.0D) {
+            this.setBoundingBox(this.getBoundingBox().move(x, y, z));
+            this.setLocationFromBoundingbox();
+        } else {
+            this.stoppedByCollision = true;
+        }
 
-            if (dY != y) {
-                this.yd = 0.0D;
-            }
+        if (dX != x) {
+            this.xd = 0.0D;
+        }
 
-            if (dZ != z) {
-                this.zd = 0.0D;
-            }
+        if (dY != y) {
+            this.yd = 0.0D;
+        }
+
+        if (dZ != z) {
+            this.zd = 0.0D;
         }
     }
 
     @Override
-    public ParticleRenderType getRenderType() {
+    public @Nonnull ParticleRenderType getRenderType() {
         return ParticleRenderType.PARTICLE_SHEET_TRANSLUCENT;
     }
 }

--- a/src/main/java/com/lootbeams/compat/ApotheosisCompat.java
+++ b/src/main/java/com/lootbeams/compat/ApotheosisCompat.java
@@ -10,15 +10,15 @@ import shadows.apotheosis.adventure.loot.LootRarity;
 public class ApotheosisCompat {
 
     public static String getRarityName(ItemStack stack){
-        if(!isApotheosisItem(stack)) return null;
-        if(stack.getItem() instanceof SalvageItem salvageItem){
+        if (!isApotheosisItem(stack)) return null;
+        if (stack.getItem() instanceof SalvageItem salvageItem) {
             return AdventureModule.RARITY_MATERIALS.inverse().get(salvageItem).id().toLowerCase();
         }
-        if(stack.getItem() instanceof GemItem gemItem){
+        if (stack.getItem() instanceof GemItem) {
             return GemItem.getLootRarity(stack).id().toLowerCase();
         }
         LootRarity rarity = AffixHelper.getRarity(stack);
-        if(rarity == null) return stack.getRarity().name().toLowerCase();
+        if (rarity == null) return stack.getRarity().name().toLowerCase();
         return rarity.id().toLowerCase();
     }
 


### PR DESCRIPTION
## Description
Bringing back some cleanup from a past PR. Helps make the code more readable and also helps with code quality.

## Proposed Changes
- In a variety of classes (`Configuration`, `VFXParticle`, `LootBeamRenderer`, `ApotheosisCompat`) high levels of indentation has been mitigated or removed through the use of guard statements. Spaces have been added between {} and calls to increase visibility. Empty lines added in places to denote a different group of code or just increase readability. Name scheme has been updated in places to consistently use camelCase. As well as just general cleanup. (Removing Unused variables, fields, imports, methods, etc)
- In `LootBeamRenderer` specifically, some nearly identical methods have been merged and parameter names have been updated to be easier to understand. Some comments have had a space added between the // and the actual comment. If statements have been merged together, etc. 

As of now this PR is: **untested**